### PR TITLE
New 'strictTransitions' builder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,17 @@ StateMachine<State, Event> stateMachine =
 
 stateMachine.apply(Event.RUN);
 ```
+
+### Non-strict transition mode
+
+By default, applying an event which does not cause a state transition throws an **UnexpectedEventTypeException**. This behavior can be disabled by setting **strictTransitions** to false when building the state machine.
+
+```java
+StateMachine<State, EventType> stateMachine =
+  new StateMachineBuilder<State, EventType>(State.INIT)
+    .strictTransitions(false)
+    .build();
+
+// No longer throws an exception
+stateMachine.apply(EventType.RUN);
+``` 

--- a/src/main/java/com/github/zevada/stateful/StateMachine.java
+++ b/src/main/java/com/github/zevada/stateful/StateMachine.java
@@ -8,9 +8,11 @@ package com.github.zevada.stateful;
  */
 public final class StateMachine<State extends Enum<State>, EventType extends Enum<EventType>> {
   private Node<State, EventType> root;
+  private boolean strictTransitions;
 
-  StateMachine(Node<State, EventType> root) {
+  StateMachine(Node<State, EventType> root, boolean strictTransitions) {
     this.root = root;
+    this.strictTransitions = strictTransitions;
   }
 
   /**
@@ -22,7 +24,11 @@ public final class StateMachine<State extends Enum<State>, EventType extends Enu
     Node<State, EventType> nextNode = root.getNeighbor(eventType);
 
     if (nextNode == null) {
-      throw new UnexpectedEventTypeException(root.getState(), eventType);
+      if (strictTransitions) {
+        throw new UnexpectedEventTypeException(root.getState(), eventType);
+      } else {
+        return;
+      }
     }
 
     root.onExit();

--- a/src/main/java/com/github/zevada/stateful/StateMachineBuilder.java
+++ b/src/main/java/com/github/zevada/stateful/StateMachineBuilder.java
@@ -12,6 +12,8 @@ import java.util.Map;
 final public class StateMachineBuilder<State extends Enum<State>, EventType extends Enum<EventType>> {
   private final Map<State, Node<State, EventType>> nodes;
   private final Node<State, EventType> root;
+  private boolean strictTransitions = true;
+
 
   /**
    * @param initialState the initial state of the state machine
@@ -30,7 +32,7 @@ final public class StateMachineBuilder<State extends Enum<State>, EventType exte
    * @return the final state machine
    */
   public StateMachine<State, EventType> build() {
-    return new StateMachine<>(root);
+    return new StateMachine<>(root, strictTransitions);
   }
 
   /**
@@ -97,6 +99,16 @@ final public class StateMachineBuilder<State extends Enum<State>, EventType exte
     }
 
     node.addOnExitListener(onExit);
+
+    return this;
+  }
+
+  /**
+   * Configures whether or not applying a state with no available transition throws an exception.
+   * @param strictTransitions If true, calling apply with an invalid transition will throw.
+   */
+  public StateMachineBuilder<State, EventType> strictTransitions(boolean strictTransitions) {
+    this.strictTransitions = strictTransitions;
 
     return this;
   }

--- a/src/test/java/com/github/zevada/stateful/StateMachineTest.java
+++ b/src/test/java/com/github/zevada/stateful/StateMachineTest.java
@@ -80,4 +80,14 @@ public class StateMachineTest {
 
     stateMachine.apply(EventType.RUN);
   }
+
+  @Test
+  public void testUnexpectedEventTypeExceptionIsNotThrown() {
+    StateMachine<State, EventType> stateMachine =
+      new StateMachineBuilder<State, EventType>(State.INIT)
+        .strictTransitions(false)
+        .build();
+
+    stateMachine.apply(EventType.RUN);
+  }
 }


### PR DESCRIPTION
New configuration to set whether or not `UnexpectedEventTypeException` is thrown when `apply` is called with an unused event.