### PR TITLE
Allow a Context object to be passed in when applying transition events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,22 @@ enum Event {
   RUN, END
 }
 
+static class Context {
+  public String message;
+
+  public Context(String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}
+
 ...
 
-StateMachine<State, Event> stateMachine =
-  new StateMachineBuilder<State, Event>(State.INIT)
+StateMachine<State, Event, Context> stateMachine =
+  new StateMachineBuilder<State, Event, Context>(State.INIT)
     .addTransition(State.INIT, Event.RUN, State.RUNNING)
     .addTransition(State.RUNNING, Event.END, State.COMPLETED)
     .build();
@@ -46,14 +58,26 @@ stateMachine.getState(); // State.RUNNING
 ### On State Enter/Exit Listeners
 
 ```java
-StateMachine<State, Event> stateMachine =
-  new StateMachineBuilder<State, Event>(State.INIT)
+StateMachine<State, Event, Context> stateMachine =
+  new StateMachineBuilder<State, Event, Context>(State.INIT)
     .addTransition(State.INIT, Event.RUN, State.RUNNING)
-    .onExit(State.INIT, () -> System.out.println("Exiting Init!"))
-    .onEnter(State.RUNNING, () -> System.out.println("Entering Running!"))
+    .onExit(State.INIT, (context) -> System.out.println("Exiting Init!"))
+    .onEnter(State.RUNNING, (context) -> System.out.println("Entering Running!"))
     .build();
 
 stateMachine.apply(Event.RUN);
+```
+
+In addition to applying simple events, a context may be passed in to allow further decoupling of application concerns:
+```java
+StateMachine<State, Event, Context> stateMachine =
+  new StateMachineBuilder<State, Event, Context>(State.INIT)
+    .addTransition(State.INIT, Event.RUN, State.RUNNING)
+    .onExit(State.INIT, (context) -> System.out.println("Exiting Init: " + String.valueOf(context)))
+    .onEnter(State.RUNNING, (context) -> System.out.println("Entering Running: " + String.valueOf(context)))
+    .build();
+
+stateMachine.apply(Event.RUN, new Context("Started at: " + new Date()));
 ```
 
 ### Non-strict transition mode
@@ -61,11 +85,11 @@ stateMachine.apply(Event.RUN);
 By default, applying an event which does not cause a state transition throws an **UnexpectedEventTypeException**. This behavior can be disabled by setting **strictTransitions** to false when building the state machine.
 
 ```java
-StateMachine<State, EventType> stateMachine =
-  new StateMachineBuilder<State, EventType>(State.INIT)
+StateMachine<State, Event, Context> stateMachine =
+  new StateMachineBuilder<State, Event, Context>(State.INIT)
     .strictTransitions(false)
     .build();
 
 // No longer throws an exception
-stateMachine.apply(EventType.RUN);
+stateMachine.apply(Event.RUN);
 ``` 

--- a/README.md
+++ b/README.md
@@ -55,3 +55,17 @@ StateMachine<State, Event> stateMachine =
 
 stateMachine.apply(Event.RUN);
 ```
+
+### Non-strict transition mode
+
+By default, applying an event which does not cause a state transition throws an **UnexpectedEventTypeException**. This behavior can be disabled by setting **strictTransitions** to false when building the state machine.
+
+```java
+StateMachine<State, EventType> stateMachine =
+  new StateMachineBuilder<State, EventType>(State.INIT)
+    .strictTransitions(false)
+    .build();
+
+// No longer throws an exception
+stateMachine.apply(EventType.RUN);
+``` 

--- a/src/main/java/com/github/zevada/stateful/Node.java
+++ b/src/main/java/com/github/zevada/stateful/Node.java
@@ -5,10 +5,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-final class Node<State extends Enum<State>, EventType extends Enum<EventType>> {
-  private final Map<EventType, Node<State, EventType>> neighbors;
-  private final List<Runnable> onEnterListeners;
-  private final List<Runnable> onExitListeners;
+final class Node<State extends Enum<State>, EventType extends Enum<EventType>, Context> {
+  protected final Map<EventType, Node<State, EventType, Context>> neighbors;
+  private final List<StatefulFunction<Context>> onEnterListeners;
+  private final List<StatefulFunction<Context>> onExitListeners;
   private final State state;
 
   Node(State state) {
@@ -22,27 +22,27 @@ final class Node<State extends Enum<State>, EventType extends Enum<EventType>> {
     return state;
   }
 
-  public Node<State, EventType> getNeighbor(EventType eventType) {
+  public Node<State, EventType, Context> getNeighbor(EventType eventType) {
     return neighbors.get(eventType);
   }
 
-  public void onEnter() {
-    onEnterListeners.forEach(Runnable::run);
+  public void onEnter(Context c) {
+    onEnterListeners.forEach(f -> f.transition(c));
   }
 
-  public void onExit() {
-    onExitListeners.forEach(Runnable::run);
+  public void onExit(Context c) {
+    onExitListeners.forEach(f -> f.transition(c));
   }
 
-  public void addNeighbor(EventType eventType, Node<State, EventType> destination) {
+  public void addNeighbor(EventType eventType, Node<State, EventType, Context> destination) {
     neighbors.put(eventType, destination);
   }
 
-  public void addOnEnterListener(Runnable onEnterListener) {
+  public void addOnEnterListener(StatefulFunction<Context> onEnterListener) {
     onEnterListeners.add(onEnterListener);
   }
 
-  public void addOnExitListener(Runnable onExitListener) {
+  public void addOnExitListener(StatefulFunction<Context> onExitListener) {
     onExitListeners.add(onExitListener);
   }
 }

--- a/src/main/java/com/github/zevada/stateful/StateMachine.java
+++ b/src/main/java/com/github/zevada/stateful/StateMachine.java
@@ -8,9 +8,11 @@ package com.github.zevada.stateful;
  */
 public final class StateMachine<State extends Enum<State>, EventType extends Enum<EventType>> {
   private Node<State, EventType> root;
+  private boolean strictTransitions;
 
-  StateMachine(Node<State, EventType> root) {
+  StateMachine(Node<State, EventType> root, boolean strictTransitions) {
     this.root = root;
+    this.strictTransitions = strictTransitions;
   }
 
   /**
@@ -22,7 +24,11 @@ public final class StateMachine<State extends Enum<State>, EventType extends Enu
     Node<State, EventType> nextNode = root.getNeighbor(eventType);
 
     if (nextNode == null) {
-      throw new UnexpectedEventTypeException(root.getState(), eventType);
+      if (strictTransitions) {
+        throw new UnexpectedEventTypeException(root.getState(), eventType);
+      } else {
+        return;
+      }
     }
 
     root.onExit();

--- a/src/main/java/com/github/zevada/stateful/StateMachine.java
+++ b/src/main/java/com/github/zevada/stateful/StateMachine.java
@@ -6,22 +6,30 @@ package com.github.zevada.stateful;
  * @param <State> The state of the entity
  * @param <EventType> The event type to be handled
  */
-public final class StateMachine<State extends Enum<State>, EventType extends Enum<EventType>> {
-  private Node<State, EventType> root;
+public final class StateMachine<State extends Enum<State>, EventType extends Enum<EventType>, Context> {
+  private Node<State, EventType, Context> root;
   private boolean strictTransitions;
 
-  StateMachine(Node<State, EventType> root, boolean strictTransitions) {
+  StateMachine(Node<State, EventType, Context> root, boolean strictTransitions) {
     this.root = root;
     this.strictTransitions = strictTransitions;
+  }
+
+  /**
+   * Apply an event to the state machine with no context object.
+   */
+  public void apply(EventType eventType) {
+    apply(eventType, null);
   }
 
   /**
    * Apply an event to the state machine.
    *
    * @param eventType The event type to be handled
+   * @param context A context to pass into the transition function
    */
-  public void apply(EventType eventType) {
-    Node<State, EventType> nextNode = root.getNeighbor(eventType);
+  public void apply(EventType eventType, Context context) {
+    Node<State, EventType, Context> nextNode = root.getNeighbor(eventType);
 
     if (nextNode == null) {
       if (strictTransitions) {
@@ -31,9 +39,9 @@ public final class StateMachine<State extends Enum<State>, EventType extends Enu
       }
     }
 
-    root.onExit();
+    root.onExit(context);
     root = nextNode;
-    root.onEnter();
+    root.onEnter(context);
   }
 
   /**

--- a/src/main/java/com/github/zevada/stateful/StateMachineBuilder.java
+++ b/src/main/java/com/github/zevada/stateful/StateMachineBuilder.java
@@ -12,6 +12,8 @@ import java.util.Map;
 final public class StateMachineBuilder<State extends Enum<State>, EventType extends Enum<EventType>> {
   private final Map<State, Node<State, EventType>> nodes;
   private final Node<State, EventType> root;
+  private boolean strictTransitions = true;
+
 
   /**
    * @param initialState the initial state of the state machine
@@ -30,7 +32,7 @@ final public class StateMachineBuilder<State extends Enum<State>, EventType exte
    * @return the final state machine
    */
   public StateMachine<State, EventType> build() {
-    return new StateMachine<>(root);
+    return new StateMachine<>(root, strictTransitions);
   }
 
   /**
@@ -97,6 +99,16 @@ final public class StateMachineBuilder<State extends Enum<State>, EventType exte
     }
 
     node.addOnExitListener(onExit);
+
+    return this;
+  }
+
+  /**
+   * Configures whether or not applying a state with no available transition throws an exception.
+   * @param strictTransitions If true, calling apply with an invalid transition will throw.
+   */
+  public StateMachineBuilder<State, EventType> strictTransitions(boolean strictTransitions) {
+    this.strictTransitions = strictTransitions;
 
     return this;
   }

--- a/src/main/java/com/github/zevada/stateful/StateMachineBuilder.java
+++ b/src/main/java/com/github/zevada/stateful/StateMachineBuilder.java
@@ -9,9 +9,9 @@ import java.util.Map;
  * @param <State> The state of the entity
  * @param <EventType> The event type to be handled
  */
-final public class StateMachineBuilder<State extends Enum<State>, EventType extends Enum<EventType>> {
-  private final Map<State, Node<State, EventType>> nodes;
-  private final Node<State, EventType> root;
+final public class StateMachineBuilder<State extends Enum<State>, EventType extends Enum<EventType>, Context> {
+  private final Map<State, Node<State, EventType, Context>> nodes;
+  private final Node<State, EventType, Context> root;
   private boolean strictTransitions = true;
 
 
@@ -31,7 +31,7 @@ final public class StateMachineBuilder<State extends Enum<State>, EventType exte
    *
    * @return the final state machine
    */
-  public StateMachine<State, EventType> build() {
+  public StateMachine<State, EventType, Context> build() {
     return new StateMachine<>(root, strictTransitions);
   }
 
@@ -43,15 +43,15 @@ final public class StateMachineBuilder<State extends Enum<State>, EventType exte
    * @param eventType the event type that triggered the transition
    * @param endState the end state of the transition
    */
-  public StateMachineBuilder<State, EventType> addTransition(State startState, EventType eventType, State endState) {
-    Node<State, EventType> startNode = nodes.get(startState);
+  public StateMachineBuilder<State, EventType, Context> addTransition(State startState, EventType eventType, State endState) {
+    Node<State, EventType, Context> startNode = nodes.get(startState);
 
     if (startNode == null) {
       startNode = new Node<>(startState);
       nodes.put(startState, startNode);
     }
 
-    Node<State, EventType> endNode = nodes.get(endState);
+    Node<State, EventType, Context> endNode = nodes.get(endState);
 
     if (endNode == null) {
       endNode = new Node<>(endState);
@@ -70,8 +70,8 @@ final public class StateMachineBuilder<State extends Enum<State>, EventType exte
    * @param state The state for which we are listening to onEnter events
    * @param onEnter The runnable to call when the state is entered
    */
-  public StateMachineBuilder<State, EventType> onEnter(State state, Runnable onEnter) {
-    Node<State, EventType> node = nodes.get(state);
+  public StateMachineBuilder<State, EventType, Context> onEnter(State state, StatefulFunction<Context> onEnter) {
+    Node<State, EventType, Context> node = nodes.get(state);
 
     if (node == null) {
       node = new Node<>(state);
@@ -90,8 +90,8 @@ final public class StateMachineBuilder<State extends Enum<State>, EventType exte
    * @param state The state for which we are listening to onExit events
    * @param onExit The runnable to call when the state is exited
    */
-  public StateMachineBuilder<State, EventType> onExit(State state, Runnable onExit) {
-    Node<State, EventType> node = nodes.get(state);
+  public StateMachineBuilder<State, EventType, Context> onExit(State state, StatefulFunction<Context> onExit) {
+    Node<State, EventType, Context> node = nodes.get(state);
 
     if (node == null) {
       node = new Node<>(state);
@@ -107,7 +107,7 @@ final public class StateMachineBuilder<State extends Enum<State>, EventType exte
    * Configures whether or not applying a state with no available transition throws an exception.
    * @param strictTransitions If true, calling apply with an invalid transition will throw.
    */
-  public StateMachineBuilder<State, EventType> strictTransitions(boolean strictTransitions) {
+  public StateMachineBuilder<State, EventType, Context> strictTransitions(boolean strictTransitions) {
     this.strictTransitions = strictTransitions;
 
     return this;

--- a/src/main/java/com/github/zevada/stateful/StatefulFunction.java
+++ b/src/main/java/com/github/zevada/stateful/StatefulFunction.java
@@ -1,0 +1,12 @@
+package com.github.zevada.stateful;
+
+/**
+ * A callback to execute during state transition.
+ *
+ * @param <Context> A context object which may be provided when applying an event.
+ */
+@FunctionalInterface
+public interface StatefulFunction<Context> {
+  void transition(Context c);
+}
+

--- a/src/test/java/com/github/zevada/stateful/StateMachineTest.java
+++ b/src/test/java/com/github/zevada/stateful/StateMachineTest.java
@@ -80,4 +80,14 @@ public class StateMachineTest {
 
     stateMachine.apply(EventType.RUN);
   }
+
+  @Test
+  public void testUnexpectedEventTypeExceptionIsNotThrown() {
+    StateMachine<State, EventType> stateMachine =
+      new StateMachineBuilder<State, EventType>(State.INIT)
+        .strictTransitions(false)
+        .build();
+
+    stateMachine.apply(EventType.RUN);
+  }
 }

--- a/src/test/java/com/github/zevada/stateful/StateMachineTest.java
+++ b/src/test/java/com/github/zevada/stateful/StateMachineTest.java
@@ -13,10 +13,22 @@ public class StateMachineTest {
     RUN, PAUSE, END
   }
 
+  static class Context {
+    public String message;
+
+    public Context(String message) {
+      this.message = message;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+  }
+
   @Test
   public void testStateMachineTransitions() {
-    StateMachine<State, EventType> stateMachine =
-      new StateMachineBuilder<State, EventType>(State.INIT)
+    StateMachine<State, EventType, Context> stateMachine =
+      new StateMachineBuilder<State, EventType, Context>(State.INIT)
         .addTransition(State.INIT, EventType.RUN, State.RUNNING)
         .addTransition(State.RUNNING, EventType.PAUSE, State.PAUSED)
         .addTransition(State.RUNNING, EventType.END, State.COMPLETED)
@@ -46,10 +58,10 @@ public class StateMachineTest {
   public void testOnStateEnterListener() {
     final boolean[] onEntered = {false};
 
-    StateMachine<State, EventType> stateMachine =
-      new StateMachineBuilder<State, EventType>(State.INIT)
+    StateMachine<State, EventType, Context> stateMachine =
+      new StateMachineBuilder<State, EventType, Context>(State.INIT)
         .addTransition(State.INIT, EventType.RUN, State.RUNNING)
-        .onEnter(State.RUNNING, () -> onEntered[0] = true)
+        .onEnter(State.RUNNING, (c) -> onEntered[0] = true)
         .build();
 
     stateMachine.apply(EventType.RUN);
@@ -61,10 +73,10 @@ public class StateMachineTest {
   public void testOnStateExitListener() {
     final boolean[] onExited = {false};
 
-    StateMachine<State, EventType> stateMachine =
-      new StateMachineBuilder<State, EventType>(State.INIT)
+    StateMachine<State, EventType, Context> stateMachine =
+      new StateMachineBuilder<State, EventType, Context>(State.INIT)
         .addTransition(State.INIT, EventType.RUN, State.RUNNING)
-        .onExit(State.INIT, () -> onExited[0] = true)
+        .onExit(State.INIT, (c) -> onExited[0] = true)
         .build();
 
     stateMachine.apply(EventType.RUN);
@@ -74,8 +86,8 @@ public class StateMachineTest {
 
   @Test(expected = UnexpectedEventTypeException.class)
   public void testUnexpectedEventTypeExceptionIsThrown() {
-    StateMachine<State, EventType> stateMachine =
-      new StateMachineBuilder<State, EventType>(State.INIT)
+    StateMachine<State, EventType, Context> stateMachine =
+      new StateMachineBuilder<State, EventType, Context>(State.INIT)
         .build();
 
     stateMachine.apply(EventType.RUN);
@@ -83,11 +95,28 @@ public class StateMachineTest {
 
   @Test
   public void testUnexpectedEventTypeExceptionIsNotThrown() {
-    StateMachine<State, EventType> stateMachine =
-      new StateMachineBuilder<State, EventType>(State.INIT)
+    StateMachine<State, EventType, Context> stateMachine =
+      new StateMachineBuilder<State, EventType, Context>(State.INIT)
         .strictTransitions(false)
         .build();
 
     stateMachine.apply(EventType.RUN);
   }
+
+  @Test
+  public void testApplyWithContext() {
+    final String[] contextReceived = {""};
+    String expectedMessage = "message";
+
+    StateMachine<State, EventType, Context> stateMachine =
+      new StateMachineBuilder<State, EventType, Context>(State.INIT)
+        .addTransition(State.INIT, EventType.RUN, State.RUNNING)
+        .onExit(State.INIT, (c) -> contextReceived[0] = c.message)
+        .build();
+
+    stateMachine.apply(EventType.RUN, new Context(expectedMessage));
+
+    assertEquals(expectedMessage, contextReceived[0]);
+  }
 }
+


### PR DESCRIPTION
This builds on the `strictTransition` feature.  It broke backward compatibility so I'm making a separate PR.

Basically, you'd now create your state machine with an additional type parameter to specify a context object which may be passed in with the `apply` method. Instead of using `Runnable`, there is a new `StatefulFunction` which passes the `Context` into the onEnter/onExit listeners. They can still be created with Java8 lambdas but with a new parameter.

I updated the README and added a test case so you can see exactly how it works.

